### PR TITLE
Fixed a bug

### DIFF
--- a/lib/summary.js
+++ b/lib/summary.js
@@ -52,7 +52,7 @@ function getBestSentence(paragraph, sentences_dict, callback) {
 
 function getSortedSentences(paragraph, sentences_dict, n, callback) {
 	splitContentToSentences(paragraph, function(sentences) {
-		if (sentences.length < 2) return "";
+		if (sentences.length < 2) return callback("");
 
 		var sentence_scores = [], strip_s;
 		_.each(sentences, function(s) {
@@ -147,7 +147,7 @@ exports.getSortedSentences = function(content, n, callback) {
 	getSentencesRanks(content, function(dict) {
 		getSortedSentences(content, dict, n, function(sorted_sentences) {
 			if(sorted_sentences === "") {
-				callback(new Error());
+				callback(new Error('Too short to summarize.'));
 			} else {
 				callback(null, sorted_sentences);
 			}


### PR DESCRIPTION
In `getSortedSentences(...)`, there was a bug that doesn't call its callback function when the paragraph is too short. Fixed it.

Sorry, too many pull-requests. I'll do more concentrate on a next job.
Thank you.
