### PR TITLE
short circuit match to empty array

### DIFF
--- a/lib/summary.js
+++ b/lib/summary.js
@@ -6,7 +6,7 @@ function splitContentToSentences(content, callback) {
 	}
 
 	content = content.replace("\n", '. ');
-	callback(content.match(/(.+?\.(?:\s|$))/g));
+	callback(content.match(/(.+?\.(?:\s|$))/g) || []);
 }
 
 function splitContentToParagraphs(content, callback) {


### PR DESCRIPTION
This fixes a rare bug where the paragraph can't be split into sentences and `.match()` returns null. I encountered this while testing using Wikipedia articles. The citation markers are causing the regex to ignore sentences, e.g. "This is a sentence.[1]" is omitted, and in some cases, no results are found.

It would be nice to have these sentences included the summary, but I'd rather not mess with the regex to handle an edge case. I just added a short circuit to avoid the error.
