### PR TITLE
Intersect function doesn't work causing summary results to be unreliable

### DIFF
--- a/lib/summary.js
+++ b/lib/summary.js
@@ -13,27 +13,6 @@ function splitContentToParagraphs(content, callback) {
 	callback(content.split("\n\n"));
 }
 
-/**
- * Original code from http://stackoverflow.com/a/1885660/394013
- */ 
-function intersect_safe(a, b) {
-  var ai     = 0, bi=0;
-  var result = [];
-
-	while(ai < a.length && bi < b.length){
-		if      (a[ai] < b[bi] ){ ai++; }
-		else if (a[ai] > b[bi] ){ bi++; }
-		else /* they're equal */
-		{
-			result.push(a[ai]);
-			ai++;
-			bi++;
-		}
-	}
-
-	return result;
-}
-
 function sentencesIntersection(sent1, sent2, callback) {
 	var s1 = sent1.split(' ');
 	var s2 = sent2.split(' ');
@@ -42,9 +21,9 @@ function sentencesIntersection(sent1, sent2, callback) {
 		callback(true);
 	}
 
-	var intersect  = intersect_safe(s1, s2);
+	var intersect  = _.intersection(s1, s2);
 	var spliceHere = ((s1.length + s2.length) / 2);
-	
+
 	callback(false, intersect.splice(0, spliceHere).length);
 }
 
@@ -101,7 +80,7 @@ function getSortedSentences(paragraph, sentences_dict, n, callback) {
 			n = sentence_scores.length;
 		}
 		sentence_scores = sentence_scores.slice(0, n);
-		
+
 		sentence_scores = _.sortBy(sentence_scores, function(sentence) {
 			return sentence.order;
 		});
@@ -109,7 +88,7 @@ function getSortedSentences(paragraph, sentences_dict, n, callback) {
 		sorted_sentences = _.pluck(sentence_scores, 'sentence');
 
 		callback(sorted_sentences);
-	});	
+	});
 }
 
 function getSentencesRanks(content, callback) {
@@ -164,7 +143,7 @@ exports.summarize = function(title, content, callback) {
 					if(sentence) summary.push(sentence);
 				});
 			});
-			
+
 			// If we only have a title, then there is an issue.
 			if(sentence.length === 2) err = true;
 			callback(err, summary.join("\n"));


### PR DESCRIPTION
Hi,

I don't think this module actually works as intended because there is an issue with how you are calculating sentence intersections.

The `intersect_safe` function assumes that the lists it is comparing are already sorted. If the lists aren't sorted, it doesn't return the correct intersection.

The way it's used in the code, the lists being compared aren't sorted. So the `intersect_safe` function doesn't return the correct word intersections between sentences which throws the end results off.

A simple fix is to just use the built-in lodash `intersection` function instead of using the custom one.  It looks like you used to do this but the behavior changed in 3d9e24d11a5a5088e85cd861cdf5293a105ffa58.

Here's a test case that shows the broken behavior:

``` javascript
var _ = require('lodash-node/underscore');

function intersect_safe(a, b) {
  var ai     = 0, bi=0;
  var result = [];

    while(ai < a.length && bi < b.length){
        if      (a[ai] < b[bi] ){ ai++; }
        else if (a[ai] > b[bi] ){ bi++; }
        else /* they're equal */
        {
            result.push(a[ai]);
            ai++;
            bi++;
        }
    }

    return result;
}

s1 = "The game's setting is memorable and quirky, with inexplicable animal-human hybrid inhabitants like the Goatician, a goat-man Magician who sells health upgrades, or the Troupple King, a gigantic, apple-shaped fish who, after a ceremonial dance, spits out various flavors of helpful potions.";
s2 = "There's a bunch of upgrades, equipment and items to purchase from the vendors in Shovel Knight's world, but you'll earn enough cash to buy all of them well before the game's ending.";

l1 = s1.split(" ");
l2 = s2.split(" ");

console.log("Unsorted lists - intersect_safe results the wrong results:")
console.log(intersect_safe(l1, l2));
console.log(_.intersection(l1, l2));

console.log("If the lists were sorted, the results would be correct-ish:")
l1.sort();
l2.sort();
console.log(intersect_safe(l1, l2));
console.log(_.intersection(l1, l2));
```

And here's the output:

```
Unsorted lists - intersect_safe results the wrong results:
[]
[ 'game\'s', 'and', 'the', 'a', 'upgrades,', 'of' ]

If the lists were sorted, the results would be correct-ish:
[ 'a', 'and', 'game\'s', 'of', 'the', 'the', 'upgrades,' ]
[ 'a', 'and', 'game\'s', 'of', 'the', 'upgrades,' ]
```

Thanks!
