### PR TITLE
Updated package.json with lodash-node dependency version | Fixes 'cannot...

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "algorithm"
   ],
   "dependencies": {
-    "lodash-node": "*"
+    "lodash-node": "2.4.1"
   },
   "devDependencies": {
     "mocha": "1.15.1",


### PR DESCRIPTION
... find module 'lodash-node/underscore' issue.

Lodash-Node has been recently updated. It no longer has an 'underscore' folder and as a consequence there's an error:

```
Error: Cannot find module 'lodash-node/underscore'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
.................
```

This commit fixes the issue by using an appropriate version of `lodash`