### PR TITLE
Summarizing Breaks when Title is Missing

### DIFF
--- a/lib/summary.js
+++ b/lib/summary.js
@@ -171,7 +171,7 @@ exports.summarize = function(title, content, callback, sentences_dict) {
 	}
 	getSentencesRanks(content, function(dict) {
 		splitContentToParagraphs(content, function(paragraphs) {
-			summary.push(title || "") // Store the title.
+			summary.push(title) // Store the title.
 
 			_.each(paragraphs, function(p) {
 				getBestSentence(p, dict, function(sentence) {

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -162,9 +162,16 @@ function getSentencesRanks(content, callback, sentences_dict) {
 
 exports.summarize = function(title, content, callback, sentences_dict) {
 	var summary = [], paragraphs = [], sentence = '', err = false
+	if(arguments.length < 3) {
+		if(content.constructor === Function) {
+			callback = content
+			content = title
+			title = ""
+		}
+	}
 	getSentencesRanks(content, function(dict) {
 		splitContentToParagraphs(content, function(paragraphs) {
-			summary.push(title) // Store the title.
+			summary.push(title || "") // Store the title.
 
 			_.each(paragraphs, function(p) {
 				getBestSentence(p, dict, function(sentence) {


### PR DESCRIPTION
This allows a user to still have an article summarized even if they forget to pass in a proper title. 